### PR TITLE
Add patch to address linking issue with Image of deque in Explicit

### DIFF
--- a/recipe/0001-Remove-forward-declaration-of-Image-of-deque.patch
+++ b/recipe/0001-Remove-forward-declaration-of-Image-of-deque.patch
@@ -1,0 +1,26 @@
+From 8be72ffab3eec385b2408bd633e37658bd3a0a17 Mon Sep 17 00:00:00 2001
+From: Bradley Lowekamp <blowekamp@mail.nih.gov>
+Date: Mon, 26 Jul 2021 18:16:08 +0000
+Subject: [PATCH] Remove forward declaration of Image of deque
+
+The resolved linking errors when explicit instantiating is used.
+---
+ Code/Explicit/include/sitkExplicitITKImage.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/Code/Explicit/include/sitkExplicitITKImage.h b/Code/Explicit/include/sitkExplicitITKImage.h
+index d8137780..242bb925 100644
+--- a/Code/Explicit/include/sitkExplicitITKImage.h
++++ b/Code/Explicit/include/sitkExplicitITKImage.h
+@@ -61,8 +61,6 @@ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::complex<doubl
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::complex<double>, 3u>;
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::complex<float>, 2u>;
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::complex<float>, 3u>;
+-extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::deque<itk::LabelObjectLine<2u>, std::allocator<itk::LabelObjectLine<2u> > >, 1u>;
+-extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<std::deque<itk::LabelObjectLine<3u>, std::allocator<itk::LabelObjectLine<3u> > >, 2u>;
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<unsigned char, 1u>;
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<unsigned char, 2u>;
+ extern template class SITKExplicit_EXPORT_EXPLICIT itk::Image<unsigned char, 3u>;
+-- 
+2.25.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ test:
 
 about:
   home: http::/www.simpleitk.org
-  license: Apache 2.0
+  license: Apache-2.0
   license_file: LICENSE
   summary: Development headers and libraries for SimpleITK a simplified interface to the Insight Toolkit.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [ win and py27]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ package:
 source:
   url: https://github.com/SimpleITK/SimpleITK/releases/download/v{{ version }}/SimpleITK-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    -  0001-Remove-forward-declaration-of-Image-of-deque.patch
 
 build:
   number: 2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
