### PR TITLE
Set to two jobs in CMake build of example.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1ef3642b0695c8eb0a0193fefe7677c57bce94a86d6b01f48f58b2291b4ca935
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -37,7 +37,7 @@ test:
     - if not exist %LIBRARY_INC%\\SimpleITK* exit 1                               # [win]
     - cmake -G Ninja -D "CMAKE_SYSTEM_PREFIX_PATH:FILEPATH=${PREFIX}" ./Examples  # [not win]
     - cmake -G Ninja -D "CMAKE_SYSTEM_PREFIX_PATH:FILEPATH=%PREFIX%" -D CMAKE_BUILD_TYPE:STRING=RELEASE ./Examples     # [win]
-    - cmake --build . --config Release
+    - cmake --build . --config Release -j 2
 
 about:
   home: http://www.simpleitk.org


### PR DESCRIPTION
This may address an issue with running out of memory on aarch64 CI builds.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
